### PR TITLE
Consider Prerelease Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
     - 'v*.*.*-*'
+    - 'v*.*.*-prerelease-*'
 
 env:
   IMAGE_NAME: ecsec/eidas-node
@@ -35,19 +36,39 @@ jobs:
       # Determine Tag for Docker image
       - name: Determine Tag
         id: determine-tag
-        run: echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3 | cut -c 2-)
+        run: |
+          echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3 | cut -c 2-)
+          echo ::set-output name=EIDAS_NODE_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | cut -d - -f 1 | cut -c 2-)
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
+        if : "! contains(steps.determine-tag.outputs.TAG, 'prerelease')"
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args: |
+            EIDAS_NODE_VERSION=${{ steps.determine-tag.outputs.EIDAS_NODE_VERSION }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.determine-tag.outputs.TAG }}
             ${{ env.IMAGE_NAME }}:latest
-          # build on feature branches, push only on main branch
+          push: true
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker prerelease image
+        id: build-and-push-prerelease
+        if : "contains(steps.determine-tag.outputs.TAG, 'prerelease')"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          # We need a different eIDAS-Node URL when building an image with a prerelease version
+          build-args: |
+            EIDAS_NODE_VERSION=${{ steps.determine-tag.outputs.EIDAS_NODE_VERSION }}
+            EIDAS_NODE_URL=https://ec.europa.eu/cefdigital/artifact/repository/eid/eu/eIDAS-node-prerelease/${{ steps.determine-tag.outputs.EIDAS_NODE_VERSION }}/eIDAS-node-prerelease-${{ steps.determine-tag.outputs.EIDAS_NODE_VERSION }}.zip
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.determine-tag.outputs.TAG }}
           push: true
 
   build-helm:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ USER root
 
 # Copy default WAR to Wildfly Image
 COPY --from=builder --chown=jboss:root /data/WILDFLY/EidasNode.war /opt/jboss/wildfly/standalone/deployments/eidas-node.war
-# Copy BouncyCastle to Wildfly Modules
-COPY --from=builder --chown=jboss:root /data/AdditionalFiles/Wildfly15/ /opt/jboss/wildfly/modules/system/layers/base/
+# Copy additional files to tmp
+COPY --from=builder --chown=jboss:root /data/AdditionalFiles/ /tmp/AdditionalFiles/
 # Copy customized java security properties file to /etc/java/security
 COPY docker/java_bc.security /etc/java/security/java_bc.security
 
@@ -44,6 +44,10 @@ RUN mkdir -p /config/eidas/specificProxyService && \
     mkdir -p /work && \
     chown -R jboss:root /config && \
     chown -R jboss:root /work && \
+    # Copy wildfly latest additional files to WildFly Modules
+    LATEST_ADDITIONAL_FILES=$(ls /tmp/AdditionalFiles/ | tail -n 1) && \
+    cp -r /tmp/AdditionalFiles/${LATEST_ADDITIONAL_FILES}/* /opt/jboss/wildfly/modules/system/layers/base/ && \
+    rm -r /tmp/AdditionalFiles/ && \
     # See also https://apacheignite.readme.io/docs/getting-started#running-ignite-with-java-11-and-later-versions regarding add-exports
     printf '\nJAVA_OPTS=\"$JAVA_OPTS $JAVA_OPTS_CUSTOM -Djdk.tls.client.protocols=TLSv1.2 --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --illegal-access=permit\"' \
       >> /opt/jboss/wildfly/bin/standalone.conf && \

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ helm upgrade --install ${RELEASE_NAME} -n ${NAMESPACE} --version ${VERSION} ec
 You can list all available eIDAS-Node helm charts by using the following command:
 
 ```bash
-$ helm search repo eidas-node --devel
+$ helm search repo eidas-node -l --devel
 ```
 
 For more details about the helm chart and its configuration, see [here](./helm/README.md).

--- a/publish.sh
+++ b/publish.sh
@@ -6,7 +6,7 @@ LATEST_TAG=$(git tag -l | tail -n 1)
 
 printf "Your latest release version: ${LATEST_TAG}\n"
 printf "Provide the new release version without the 'v' prefix.\n"
-read -p "What is the new release version (<EIDAS_NODE_VERSION>-<REVISION>): " NEW_TAG
+read -p "What is the new release version (<EIDAS_NODE_VERSION>[-prerelease]-<REVISION>): " NEW_TAG
 
 # Update version in helm chart
 sed -i 's@version: .*@version: '"${NEW_TAG}"'@' ${DIR}/helm/Chart.yaml


### PR DESCRIPTION
Makes it possible to build prerelease images and helm charts for the eIDAS-Node.

The tag must look like the following: `v*.*.*-prerelease-*`

I updated the Dockerfile to support eIDAS-Node additional files that are not stored in "Wildfly15". In the 2.6.0-prerelease version of the eIDAS-Node the additional files are stored in "Wildfly23". Finally, I added a new job, that builds prerelease images based on the prerelease URL.